### PR TITLE
revert(openschema-android): disable custom notification

### DIFF
--- a/openschema-android/app/src/main/java/io/openschema/client/activity/MainActivity.java
+++ b/openschema-android/app/src/main/java/io/openschema/client/activity/MainActivity.java
@@ -25,7 +25,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.util.Pair;
 import androidx.drawerlayout.widget.DrawerLayout;
-import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 import androidx.navigation.ui.AppBarConfiguration;
@@ -33,10 +32,7 @@ import androidx.navigation.ui.NavigationUI;
 import io.openschema.client.R;
 import io.openschema.client.util.ServiceStatusWorker;
 import io.openschema.client.view.CustomNotification;
-import io.openschema.client.view.NetworkQualityView;
-import io.openschema.client.viewmodel.NetworkQualityViewModel;
 import io.openschema.mma.MobileMetricsAgent;
-import io.openschema.mma.MobileMetricsService;
 import io.openschema.mma.utils.PermissionManager;
 
 public class MainActivity extends AppCompatActivity {
@@ -79,18 +75,18 @@ public class MainActivity extends AppCompatActivity {
                     .build();
 
             //Start permanent observer to update custom notification. (Only if service isn't running so that we don't create multiple observers on subsequent app starts)
-            if (!MobileMetricsService.isServiceRunning(getApplicationContext())) {
-                NetworkQualityViewModel networkQualityViewModel = new ViewModelProvider(this).get(NetworkQualityViewModel.class);
-                networkQualityViewModel.getActiveNetworkQuality().observeForever(networkStatus -> {
-                    CustomNotification customNotification = CustomNotification.getInstance(getApplicationContext());
-
-                    //Update the notification's view
-                    customNotification.updateNetworkStatus(networkStatus);
-
-                    //Update the notification shown by the OS
-                    customNotification.show(getApplicationContext());
-                });
-            }
+//            if (!MobileMetricsService.isServiceRunning(getApplicationContext())) {
+//                NetworkQualityViewModel networkQualityViewModel = new ViewModelProvider(this).get(NetworkQualityViewModel.class);
+//                networkQualityViewModel.getActiveNetworkQuality().observeForever(networkStatus -> {
+//                    CustomNotification customNotification = CustomNotification.getInstance(getApplicationContext());
+//
+//                    //Update the notification's view
+//                    customNotification.updateNetworkStatus(networkStatus);
+//
+//                    //Update the notification shown by the OS
+//                    customNotification.show(getApplicationContext());
+//                });
+//            }
 
             //Initialize agent
             mMobileMetricsAgent.init();

--- a/openschema-android/app/src/main/java/io/openschema/client/util/DeviceBootReceiver.java
+++ b/openschema-android/app/src/main/java/io/openschema/client/util/DeviceBootReceiver.java
@@ -1,6 +1,5 @@
 package io.openschema.client.util;
 
-import android.app.Application;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -8,10 +7,7 @@ import android.util.Log;
 
 import io.openschema.client.R;
 import io.openschema.client.view.CustomNotification;
-import io.openschema.client.view.NetworkQualityView;
-import io.openschema.client.viewmodel.NetworkQualityViewModel;
 import io.openschema.mma.MobileMetricsAgent;
-import io.openschema.mma.MobileMetricsService;
 import io.openschema.mma.utils.PermissionManager;
 
 public class DeviceBootReceiver extends BroadcastReceiver {
@@ -36,21 +32,21 @@ public class DeviceBootReceiver extends BroadcastReceiver {
                     .build();
 
             //Start permanent observer to update custom notification. (Only if service isn't running so that we don't create multiple observers on subsequent app starts)
-            if (!MobileMetricsService.isServiceRunning(context.getApplicationContext())) {
-                Log.d(TAG, "MMA: Setting up observer to update notification.");
-//                NetworkQualityViewModel networkQualityViewModel = new ViewModelProvider(context.getApplicationContext()).get(NetworkQualityViewModel.class);
-                NetworkQualityViewModel networkQualityViewModel = new NetworkQualityViewModel((Application) context.getApplicationContext());
-
-                networkQualityViewModel.getActiveNetworkQuality().observeForever(networkStatus -> {
-                    CustomNotification customNotification = CustomNotification.getInstance(context.getApplicationContext());
-
-                    //Update the notification's view
-                    customNotification.updateNetworkStatus(networkStatus);
-
-                    //Update the notification shown by the OS
-                    customNotification.show(context.getApplicationContext());
-                });
-            }
+//            if (!MobileMetricsService.isServiceRunning(context.getApplicationContext())) {
+//                Log.d(TAG, "MMA: Setting up observer to update notification.");
+////                NetworkQualityViewModel networkQualityViewModel = new ViewModelProvider(context.getApplicationContext()).get(NetworkQualityViewModel.class);
+//                NetworkQualityViewModel networkQualityViewModel = new NetworkQualityViewModel((Application) context.getApplicationContext());
+//
+//                networkQualityViewModel.getActiveNetworkQuality().observeForever(networkStatus -> {
+//                    CustomNotification customNotification = CustomNotification.getInstance(context.getApplicationContext());
+//
+//                    //Update the notification's view
+//                    customNotification.updateNetworkStatus(networkStatus);
+//
+//                    //Update the notification shown by the OS
+//                    customNotification.show(context.getApplicationContext());
+//                });
+//            }
 
             //Initialize agent
             Log.d(TAG, "MMA: Initializing MMA object.");

--- a/openschema-android/app/src/main/java/io/openschema/client/util/ServiceStatusWorker.java
+++ b/openschema-android/app/src/main/java/io/openschema/client/util/ServiceStatusWorker.java
@@ -1,6 +1,5 @@
 package io.openschema.client.util;
 
-import android.app.Application;
 import android.content.Context;
 import android.util.Log;
 
@@ -14,8 +13,6 @@ import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 import io.openschema.client.R;
 import io.openschema.client.view.CustomNotification;
-import io.openschema.client.view.NetworkQualityView;
-import io.openschema.client.viewmodel.NetworkQualityViewModel;
 import io.openschema.mma.MobileMetricsAgent;
 import io.openschema.mma.MobileMetricsService;
 import io.openschema.mma.metrics.HourlyUsageWorker;
@@ -51,21 +48,21 @@ public class ServiceStatusWorker extends Worker {
                 .build();
 
         //Start permanent observer to update custom notification. (Only if service isn't running so that we don't create multiple observers on subsequent app starts)
-        if (!MobileMetricsService.isServiceRunning(mContext.getApplicationContext())) {
-            Log.d(TAG, "UI: Setting up observer to update notification.");
-//                NetworkQualityViewModel networkQualityViewModel = new ViewModelProvider(context.getApplicationContext()).get(NetworkQualityViewModel.class);
-            NetworkQualityViewModel networkQualityViewModel = new NetworkQualityViewModel((Application) mContext.getApplicationContext());
-
-            networkQualityViewModel.getActiveNetworkQuality().observeForever(networkStatus -> {
-                CustomNotification customNotification = CustomNotification.getInstance(mContext.getApplicationContext());
-
-                //Update the notification's view
-                customNotification.updateNetworkStatus(networkStatus);
-
-                //Update the notification shown by the OS
-                customNotification.show(mContext.getApplicationContext());
-            });
-        }
+//        if (!MobileMetricsService.isServiceRunning(mContext.getApplicationContext())) {
+//            Log.d(TAG, "UI: Setting up observer to update notification.");
+////                NetworkQualityViewModel networkQualityViewModel = new ViewModelProvider(context.getApplicationContext()).get(NetworkQualityViewModel.class);
+//            NetworkQualityViewModel networkQualityViewModel = new NetworkQualityViewModel((Application) mContext.getApplicationContext());
+//
+//            networkQualityViewModel.getActiveNetworkQuality().observeForever(networkStatus -> {
+//                CustomNotification customNotification = CustomNotification.getInstance(mContext.getApplicationContext());
+//
+//                //Update the notification's view
+//                customNotification.updateNetworkStatus(networkStatus);
+//
+//                //Update the notification shown by the OS
+//                customNotification.show(mContext.getApplicationContext());
+//            });
+//        }
 
         //Initialize agent
         Log.d(TAG, "UI: Initializing MMA object.");

--- a/openschema-android/app/src/main/java/io/openschema/client/view/CustomNotification.java
+++ b/openschema-android/app/src/main/java/io/openschema/client/view/CustomNotification.java
@@ -3,12 +3,9 @@ package io.openschema.client.view;
 import android.app.Notification;
 import android.app.PendingIntent;
 import android.content.Context;
-import android.net.NetworkCapabilities;
 import android.os.Bundle;
-import android.widget.RemoteViews;
 
 import androidx.core.app.NotificationCompat;
-import androidx.core.app.NotificationManagerCompat;
 import androidx.navigation.NavDeepLinkBuilder;
 import io.openschema.client.R;
 import io.openschema.client.activity.MainActivity;
@@ -31,11 +28,11 @@ public class CustomNotification {
     }
 
     private NotificationCompat.Builder mCustomNotificationBuilder = null;
-    private RemoteViews mNotificationView;
+//    private RemoteViews mNotificationView;
 
     private CustomNotification(Context context) {
         init(context);
-        updateNetworkStatus(null);
+//        updateNetworkStatus(null);
     }
 
     private void init(Context context) {
@@ -49,12 +46,25 @@ public class CustomNotification {
                 .setArguments(args)
                 .createPendingIntent();
 
-        mNotificationView = new RemoteViews(context.getPackageName(), R.layout.view_custom_notification);
+        //TODO: Custom notification was disabled due to sometimes not updating correctly.
+        // We might need to implement a bound-service architecture for the notification to have a lifecycle to update from.
+
+//        mNotificationView = new RemoteViews(context.getPackageName(), R.layout.view_custom_notification);
+
+//        mCustomNotificationBuilder = new NotificationCompat.Builder(context, PersistentNotification.SERVICE_NOTIFICATION_CHANNEL_ID)
+//                .setSmallIcon(io.openschema.mma.R.drawable.ic_persistent_notification)
+//                .setCustomContentView(mNotificationView)
+//                .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
+//                .setShowWhen(false)
+//                .setCategory(NotificationCompat.CATEGORY_SERVICE)
+//                .setPriority(NotificationCompat.PRIORITY_LOW)
+//                .setContentIntent(pendingIntent);
 
         mCustomNotificationBuilder = new NotificationCompat.Builder(context, PersistentNotification.SERVICE_NOTIFICATION_CHANNEL_ID)
                 .setSmallIcon(io.openschema.mma.R.drawable.ic_persistent_notification)
-                .setCustomContentView(mNotificationView)
-                .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
+                .setContentTitle("OpenSchema is running")
+                .setContentText("Tap here for more information.")
+                .setOngoing(true) //notification can't be swiped
                 .setShowWhen(false)
                 .setCategory(NotificationCompat.CATEGORY_SERVICE)
                 .setPriority(NotificationCompat.PRIORITY_LOW)
@@ -65,33 +75,33 @@ public class CustomNotification {
         return mCustomNotificationBuilder.build();
     }
 
-    public void updateNetworkStatus(NetworkQualityView.NetworkStatus networkStatus) {
-        if (networkStatus != null) {
-            if (networkStatus.mTransportType != NetworkQualityView.NetworkStatus.MEASURING_NETWORK) {
-                int networkIcon = networkStatus.mTransportType == NetworkCapabilities.TRANSPORT_WIFI ? R.drawable.ic_notification_network_wifi : R.drawable.ic_notification_network_cellular;
+//    public void updateNetworkStatus(NetworkQualityView.NetworkStatus networkStatus) {
+//        if (networkStatus != null) {
+//            if (networkStatus.mTransportType != NetworkQualityView.NetworkStatus.MEASURING_NETWORK) {
+//                int networkIcon = networkStatus.mTransportType == NetworkCapabilities.TRANSPORT_WIFI ? R.drawable.ic_notification_network_wifi : R.drawable.ic_notification_network_cellular;
+//
+//                String networkPrimary = "Current Network: ";
+//                networkPrimary += networkStatus.mTransportType == NetworkCapabilities.TRANSPORT_WIFI ? "Wi-Fi" : "Cellular";
+//
+//                String networkQuality = "Detected Quality: " + networkStatus.getNetworkQualityString();
+//
+//                mNotificationView.setImageViewResource(R.id.notification_network_primary_icon, networkIcon);
+//                mNotificationView.setTextViewText(R.id.notification_network_primary, networkPrimary);
+//                mNotificationView.setTextViewText(R.id.notification_network_quality, networkQuality);
+//            } else {
+//                mNotificationView.setImageViewResource(R.id.notification_network_primary_icon, R.drawable.ic_notification_network_unknown);
+//                mNotificationView.setTextViewText(R.id.notification_network_primary, "Active network is being measured.");
+//                mNotificationView.setTextViewText(R.id.notification_network_quality, "");
+//            }
+//        } else {
+//            mNotificationView.setImageViewResource(R.id.notification_network_primary_icon, R.drawable.ic_notification_network_unknown);
+//            mNotificationView.setTextViewText(R.id.notification_network_primary, "No active network detected.");
+//            mNotificationView.setTextViewText(R.id.notification_network_quality, "");
+//        }
+//    }
 
-                String networkPrimary = "Current Network: ";
-                networkPrimary += networkStatus.mTransportType == NetworkCapabilities.TRANSPORT_WIFI ? "Wi-Fi" : "Cellular";
-
-                String networkQuality = "Detected Quality: " + networkStatus.getNetworkQualityString();
-
-                mNotificationView.setImageViewResource(R.id.notification_network_primary_icon, networkIcon);
-                mNotificationView.setTextViewText(R.id.notification_network_primary, networkPrimary);
-                mNotificationView.setTextViewText(R.id.notification_network_quality, networkQuality);
-            } else {
-                mNotificationView.setImageViewResource(R.id.notification_network_primary_icon, R.drawable.ic_notification_network_unknown);
-                mNotificationView.setTextViewText(R.id.notification_network_primary, "Active network is being measured.");
-                mNotificationView.setTextViewText(R.id.notification_network_quality, "");
-            }
-        } else {
-            mNotificationView.setImageViewResource(R.id.notification_network_primary_icon, R.drawable.ic_notification_network_unknown);
-            mNotificationView.setTextViewText(R.id.notification_network_primary, "No active network detected.");
-            mNotificationView.setTextViewText(R.id.notification_network_quality, "");
-        }
-    }
-
-    public void show(Context context) {
-        NotificationManagerCompat.from(context)
-                .notify(PersistentNotification.SERVICE_NOTIFICATION_ID, mCustomNotificationBuilder.build());
-    }
+//    public void show(Context context) {
+//        NotificationManagerCompat.from(context)
+//                .notify(PersistentNotification.SERVICE_NOTIFICATION_ID, mCustomNotificationBuilder.build());
+//    }
 }


### PR DESCRIPTION
The notification with a custom layout to display
network quality information has been disabled. We
had issues where the notification wasn't updating
properly after some time.